### PR TITLE
Add lease permission to create lease for core service

### DIFF
--- a/service-account.yaml
+++ b/service-account.yaml
@@ -147,6 +147,17 @@ rules:
       - scheduling.volcano.sh
     resources:
       - podgroups
+  - verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+    apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
 
 
 ---


### PR DESCRIPTION
Add lease permissions to create a lease for core service to streamline k8 events.

More info: https://iomete.atlassian.net/wiki/spaces/~712020d23fb699741c43219cdbd8e9e2517ddc/pages/96993310/Core+Service+Issues+with+K8+Events