### PR TITLE
Add statefulset permissions for app apiGroup

### DIFF
--- a/service-account.yaml
+++ b/service-account.yaml
@@ -33,6 +33,8 @@ rules:
       - pods
       - deployments
       - replicasets
+      - statefulsets
+      - statefulsets/scale
   - verbs:
       - get
     apiGroups:


### PR DESCRIPTION
In order to create event streams it is required to have `statefulsets` and `statefulsets/scale` permissions. This PR adds these permissions.